### PR TITLE
Update 04-targets.md

### DIFF
--- a/_episodes/04-targets.md
+++ b/_episodes/04-targets.md
@@ -97,7 +97,7 @@ fields at the same time.
 
 ## Example 1: Include directories
 
-When you run [`target_include_directory(TargetA PRIVATE mydir)`][`target_include_directory`], then
+When you run [`target_include_directories(TargetA PRIVATE mydir)`][`target_include_directories`], then
 the [`INCLUDE_DIRECTORIES`][] property of `TargetA` has `mydir` appended. If you use the keyword
 `INTERFACE` instead, then [`INTERFACE_INCLUDE_DIRECTORIES`][] is appended to, instead. If you use
 `PUBLIC`, then both properties are appended to at the same time.


### PR DESCRIPTION
cmake command is `target_include_directories`. In article `target_include_directory` was used.
Otherwise I didn't get the purpose of use of this  keyword.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution.

To ensure that someone gets notified, you can also click on "Request a review" and add
the suggested person.

Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact the HSF training convenors.

You may delete these instructions from your comment.

\- HSF Training
</details>
