### PR TITLE
PULL_REQUEST_TEMPLATE: remove section about requsting a review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,6 @@ Thanks for contributing! :heart:
 Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
 respond to your contribution.
 
-To ensure that someone gets notified, you can also click on "Request a review" and add
-the suggested person.
-
 Although not all contributions can be incorporated into the lesson
 materials, we appreciate your time and effort to improve the curriculum. If you have any questions
 about the lesson maintenance process or would like to volunteer your time as a contribution


### PR DESCRIPTION
As a external user, I can nether request a review nor assign a person.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution.

To ensure that someone gets notified, you can also click on "Request a review" and add
the suggested person.

Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact the HSF training convenors.

You may delete these instructions from your comment.

\- HSF Training
</details>
