### PR TITLE
fix: install Git in Docker container

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -51,7 +51,7 @@ git clone https://github.com/hsf-training/hsf-training-cmake-webpage.git
 cd hsf-training-cmake-webpage
 docker run -v $PWD:/cmake_work --rm -it alpine
 
-apk add g++ cmake make
+apk add git g++ cmake make
 cd /cmake_work
 ```
 


### PR DESCRIPTION
<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to respond to your contribution.
To ensure that the right people get notified, you can tag some of the last contributors with `@githubname`.

Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact the HSF training convenors ([contacts here](https://hepsoftwarefoundation.org/workinggroups/training.html)).

You may delete these instructions from your pull request.

\- HSF Training
</details>

In order to clone the CLI11 repository in the second episode, [Building with CMake](https://hsf-training.github.io/hsf-training-cmake-webpage/02-building/index.html), Git needs to be installed inside the Docker container