### PR TITLE
fix: install gdb in Docker container

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -17,6 +17,7 @@ On your computer, you need to have:
 * `cmake` (Version 3.15 or newer). See the [instructions here][CMake Instructions].
 * A C++ compiler - system default is fine.
 * `make` or `ninja` (unless you are using Xcode/MSVC)
+* `gdb` (required for [episode 8 on debugging]({{ page.root }}/08-debugging/))
 
 ## [Docker][] based setup
 
@@ -33,7 +34,7 @@ A quick and minimal docker:
 
 ```bash
 docker run --rm -it alpine
-apk add git g++ cmake make
+apk add git g++ cmake make gdb
 git clone https://github.com/hsf-training/hsf-training-cmake-webpage.git
 cd hsf-training-cmake-webpage
 ```
@@ -51,7 +52,7 @@ git clone https://github.com/hsf-training/hsf-training-cmake-webpage.git
 cd hsf-training-cmake-webpage
 docker run -v $PWD:/cmake_work --rm -it alpine
 
-apk add git g++ cmake make
+apk add git g++ cmake make gdb
 cd /cmake_work
 ```
 


### PR DESCRIPTION
<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to respond to your contribution.
To ensure that the right people get notified, you can tag some of the last contributors with `@githubname`.

Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact the HSF training convenors ([contacts here](https://hepsoftwarefoundation.org/workinggroups/training.html)).

You may delete these instructions from your pull request.

\- HSF Training
</details>

While I was going through episode 8, I discovered that the Docker container didn't have `gdb` installed

Note that I got the syntax for linking between files from the lesson-example [here](https://github.com/carpentries/lesson-example/blob/b92de36ea25d64a9f24c12e515b603d5127920fb/_episodes/03-organization.md?plain=1#L45) (I also confirmed on the site published from my fork that it works)