### PR TITLE
Remove wrong bracket

### DIFF
--- a/_episodes/11-functions.md
+++ b/_episodes/11-functions.md
@@ -79,6 +79,6 @@ the cost of more lines of code.
 > * Based on [Modern CMake basics/functions][]
 {:.checklist}
 
-[Modern CMake basics/functions]: https://cliutils.gitlab.io/modern-cmake/chapters/basics/functions.html]
+[Modern CMake basics/functions]: https://cliutils.gitlab.io/modern-cmake/chapters/basics/functions.html
 
 {% include links.md %}


### PR DESCRIPTION
Remove the unnecessary bracket that makes the link invalid when clicking on it.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to respond to your contribution.
To ensure that the right people get notified, you can tag some of the last contributors with `@githubname`.

Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact the HSF training convenors ([contacts here](https://hepsoftwarefoundation.org/workinggroups/training.html)).

You may delete these instructions from your pull request.

\- HSF Training
</details>
